### PR TITLE
fix: remove empty background sections in songs

### DIFF
--- a/content/music/demolition/annabelle.md
+++ b/content/music/demolition/annabelle.md
@@ -3,9 +3,6 @@ title: "Annabelle [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Annabelle sat

--- a/content/music/demolition/arise-fair-sun.md
+++ b/content/music/demolition/arise-fair-sun.md
@@ -3,9 +3,6 @@ title: "Arise Fair Sun [Alternate Version]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Romeo was young, and he was unafraid

--- a/content/music/demolition/blood-and-bone.md
+++ b/content/music/demolition/blood-and-bone.md
@@ -3,9 +3,6 @@ title: "Blood and Bone [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 with wine

--- a/content/music/demolition/card-subject-to-change.md
+++ b/content/music/demolition/card-subject-to-change.md
@@ -3,9 +3,6 @@ title: "Card Subject to Change [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 you said that blonde heels have more fun

--- a/content/music/demolition/dead-men-cant-catcall.md
+++ b/content/music/demolition/dead-men-cant-catcall.md
@@ -3,9 +3,6 @@ title: "Dead Men Can't Catcall"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Dead man can't whistle at you walking down the road

--- a/content/music/demolition/heart-in-a-jar.md
+++ b/content/music/demolition/heart-in-a-jar.md
@@ -3,9 +3,6 @@ title: "Heart in a Jar [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 She has my heart in a jar by her bedside, suspended in glittering gel.

--- a/content/music/demolition/hip-hop-halloween.md
+++ b/content/music/demolition/hip-hop-halloween.md
@@ -3,9 +3,6 @@ title: "Hip Hop Halloween"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 you gave me such a fright, oh isn't it a scream

--- a/content/music/demolition/long-sleeves-in-summer.md
+++ b/content/music/demolition/long-sleeves-in-summer.md
@@ -3,9 +3,6 @@ title: "Long Sleeves in Summer [I Believe]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 The movies are lying, it isn't romantic

--- a/content/music/demolition/partner-in-crime.md
+++ b/content/music/demolition/partner-in-crime.md
@@ -3,12 +3,9 @@ title: "Partner In Crime"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
-	
+
 those who say that love is blind
 must have never met me
 i set you in my sights

--- a/content/music/demolition/sellout.md
+++ b/content/music/demolition/sellout.md
@@ -3,9 +3,6 @@ title: "sellout! [Alternate Version]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 God I wish that I could sell out

--- a/content/music/demolition/stormy-weather.md
+++ b/content/music/demolition/stormy-weather.md
@@ -3,9 +3,6 @@ title: "Stormy Weather [from \"Manic Pixie Dream Show\"]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (spoken)

--- a/content/music/demolition/take-a-knee.md
+++ b/content/music/demolition/take-a-knee.md
@@ -3,9 +3,6 @@ title: "Take A Knee DEMO"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 you thought i would never learn to open up my cage

--- a/content/music/demolition/what-would-peggy-carter-do.md
+++ b/content/music/demolition/what-would-peggy-carter-do.md
@@ -3,9 +3,6 @@ title: "What Would Peggy Carter Do?"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 when i’m feeling down

--- a/content/music/heralds-and-harbingers-ost/ant-hill-university.md
+++ b/content/music/heralds-and-harbingers-ost/ant-hill-university.md
@@ -3,9 +3,6 @@ title: "Ant Hill University"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental track)

--- a/content/music/heralds-and-harbingers-ost/harbinger.md
+++ b/content/music/heralds-and-harbingers-ost/harbinger.md
@@ -3,9 +3,6 @@ title: "Harbinger"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental track)

--- a/content/music/heralds-and-harbingers-ost/josue.md
+++ b/content/music/heralds-and-harbingers-ost/josue.md
@@ -3,9 +3,6 @@ title: "Josue"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental track)

--- a/content/music/heralds-and-harbingers-ost/the-fire-reveals.md
+++ b/content/music/heralds-and-harbingers-ost/the-fire-reveals.md
@@ -3,9 +3,6 @@ title: "The Fire Reveals - Chikara Theme Reprise"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I used to feel down; hit the ground running

--- a/content/music/heralds-and-harbingers-ost/the-jewel.md
+++ b/content/music/heralds-and-harbingers-ost/the-jewel.md
@@ -3,9 +3,6 @@ title: "The Jewel"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental track)

--- a/content/music/idiot-child/arise-fair-sun.md
+++ b/content/music/idiot-child/arise-fair-sun.md
@@ -3,9 +3,6 @@ title: "Arise Fair Sun"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Romeo was young
@@ -38,11 +35,11 @@ At least not any more
 But girl you’re far too pretty not to kill a little for
 Arise fair sun and slay the envious moon
 For she is sick and pale with grief
-Good bye my love, for I have come too soon, 
+Good bye my love, for I have come too soon,
 You’ll not be with me with me
 
-Romeo Romeo 
-Wherefore art thou Romeo 
+Romeo Romeo
+Wherefore art thou Romeo
 I need you I need you now
 Don’t let go, don’t let go
 I could be your Romeo

--- a/content/music/idiot-child/beautiful-mistake.md
+++ b/content/music/idiot-child/beautiful-mistake.md
@@ -3,9 +3,6 @@ title: "Beautiful Mistake"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Dear dear boy
@@ -30,11 +27,11 @@ Because my hand is in your hand
 There’s fire in your eyes
 Dear dear boy
 I can’t open my heart
-If I move another inch 
+If I move another inch
 I’ll fall into your arms
 
-Hold me 
-Scold me 
+Hold me
+Scold me
 Just let me be near
 Uncover me
 Discover me
@@ -44,10 +41,10 @@ Dear dear boy
 Doing what I must
 Because someday I’ll dance away
 And leave this in the dust
-Dear dear boy 
+Dear dear boy
 With every breath I take
 Reminded of your crooked smile
-The beautiful mistake 
+The beautiful mistake
 You’re such a beautiful mistake
 (x2)
 {{< / lyrics >}}

--- a/content/music/idiot-child/domestic-rhapsody.md
+++ b/content/music/idiot-child/domestic-rhapsody.md
@@ -3,15 +3,12 @@ title: "Domestic Rhapsody"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (vocalizing)
 I can tell from the way you smile
 That you think I’m inferior
-Why don't I complain?  Because 
+Why don't I complain?  Because
 I’m used to you being superior
 
 She’s a goddess in a blue dress

--- a/content/music/idiot-child/farewell-licorice-tree.md
+++ b/content/music/idiot-child/farewell-licorice-tree.md
@@ -3,9 +3,6 @@ title: "Farewell, Licorice Tree"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Long hair, long beads

--- a/content/music/idiot-child/little-girl-big-liar.md
+++ b/content/music/idiot-child/little-girl-big-liar.md
@@ -3,9 +3,6 @@ title: "little girl, BIG LIAR"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I am watching you

--- a/content/music/idiot-child/no-parking-sign.md
+++ b/content/music/idiot-child/no-parking-sign.md
@@ -3,9 +3,6 @@ title: "No Parking Sign"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 There is a no

--- a/content/music/idiot-child/sell-out.md
+++ b/content/music/idiot-child/sell-out.md
@@ -3,9 +3,6 @@ title: "sell out!"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 God I wish that I could sell out

--- a/content/music/idiot-child/ukulele.md
+++ b/content/music/idiot-child/ukulele.md
@@ -3,9 +3,6 @@ title: "Ukulele"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You’re tall, you’re funny, and you’re smart

--- a/content/music/idiot-child/under-covers.md
+++ b/content/music/idiot-child/under-covers.md
@@ -3,9 +3,6 @@ title: "Under Covers"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 [[unintelligible]] and cheap motels and call a highway home

--- a/content/music/make-an-entrance-ep/canvas.md
+++ b/content/music/make-an-entrance-ep/canvas.md
@@ -3,9 +3,6 @@ title: "CANVAS [The Nouveau Aesthetic Theme]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Canvas, the great equalizer

--- a/content/music/make-an-entrance-ep/down-you-go.md
+++ b/content/music/make-an-entrance-ep/down-you-go.md
@@ -3,9 +3,6 @@ title: "Down You Go [Oceanea's Theme]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (Repeats throughout the song)

--- a/content/music/make-an-entrance-ep/pop-that-bubblegum.md
+++ b/content/music/make-an-entrance-ep/pop-that-bubblegum.md
@@ -3,9 +3,6 @@ title: "Pop That Bubblegum [Blanche Babbish's Theme]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I won't let you break my toys

--- a/content/music/make-an-entrance-ep/the-fire-reveals.md
+++ b/content/music/make-an-entrance-ep/the-fire-reveals.md
@@ -3,9 +3,6 @@ title: "The Fire Reveals [The Crucible Theme]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I used to feel down; hit the ground running

--- a/content/music/make-an-entrance-ep/the-mans-choir.md
+++ b/content/music/make-an-entrance-ep/the-mans-choir.md
@@ -3,9 +3,6 @@ title: "The Man's Choir [Becky Lynch's Theme Revisited]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (vocalizing without words)

--- a/content/music/sage-and-silver-bullets/bianca.md
+++ b/content/music/sage-and-silver-bullets/bianca.md
@@ -3,9 +3,6 @@ title: "Bianca"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 It's so easy to go back

--- a/content/music/sage-and-silver-bullets/black-sky-lullaby.md
+++ b/content/music/sage-and-silver-bullets/black-sky-lullaby.md
@@ -3,9 +3,6 @@ title: "Black Sky Lullaby"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 i'll be fine without you

--- a/content/music/sage-and-silver-bullets/blood-and-bone.md
+++ b/content/music/sage-and-silver-bullets/blood-and-bone.md
@@ -3,9 +3,6 @@ title: "Blood and Bone"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 i am no saint i have my sins

--- a/content/music/sage-and-silver-bullets/diagnonsense.md
+++ b/content/music/sage-and-silver-bullets/diagnonsense.md
@@ -3,9 +3,6 @@ title: "Diagnonsense"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 It was predicted by my mother's eyes

--- a/content/music/sage-and-silver-bullets/road-to-hell.md
+++ b/content/music/sage-and-silver-bullets/road-to-hell.md
@@ -3,9 +3,6 @@ title: "Road To Hell"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 i can feel it creeping up behind me

--- a/content/music/sage-and-silver-bullets/the-curse-of-eve.md
+++ b/content/music/sage-and-silver-bullets/the-curse-of-eve.md
@@ -3,9 +3,6 @@ title: "The Curse of Eve"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 you have cursed us, mother eve

--- a/content/music/singles/bean-gotta-scream.md
+++ b/content/music/singles/bean-gotta-scream.md
@@ -3,9 +3,6 @@ title: "BEAN GOTTA SCREAM feat. Winslow the Cat"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 My name is Winslow and I'm a bean

--- a/content/music/singles/big-gun-cover.md
+++ b/content/music/singles/big-gun-cover.md
@@ -3,9 +3,6 @@ title: "Big Gun COVER"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 It's goin' down. Yo the girl got a gun,

--- a/content/music/singles/cheap-thrills-cover.md
+++ b/content/music/singles/cheap-thrills-cover.md
@@ -3,9 +3,6 @@ title: "Cheap Thrills COVER"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Come on, come on, turn the radio on

--- a/content/music/singles/clint-eastwood-cover.md
+++ b/content/music/singles/clint-eastwood-cover.md
@@ -3,9 +3,6 @@ title: "Clint Eastwood COVER"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I ain't happy, I'm feeling glad

--- a/content/music/singles/fell-in-love-with-a-girl-cover.md
+++ b/content/music/singles/fell-in-love-with-a-girl-cover.md
@@ -3,9 +3,6 @@ title: "Fell In Love With A Girl COVER"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 [[lyrics need correction]]

--- a/content/music/singles/ren-faire-romance.md
+++ b/content/music/singles/ren-faire-romance.md
@@ -3,9 +3,6 @@ title: "Ren Faire Romance"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Maybe it's the way you look in your feathered cap

--- a/content/music/singles/supernova-girl-cover.md
+++ b/content/music/singles/supernova-girl-cover.md
@@ -3,9 +3,6 @@ title: "Supernova Girl [COVER]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Stargazing megafast

--- a/content/music/singles/tension-rising-deluxe.md
+++ b/content/music/singles/tension-rising-deluxe.md
@@ -3,9 +3,6 @@ title: "Tension Rising DELUXE"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental piece)

--- a/content/music/singles/tension-rising.md
+++ b/content/music/singles/tension-rising.md
@@ -3,9 +3,6 @@ title: "Tension Rising"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 (instrumental piece)

--- a/content/music/soliloquy/blood-imperial.md
+++ b/content/music/soliloquy/blood-imperial.md
@@ -3,9 +3,6 @@ title: "Blood Imperial [Bury Your Whore]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You have the blood and burial

--- a/content/music/soliloquy/in-the-dollhouse.md
+++ b/content/music/soliloquy/in-the-dollhouse.md
@@ -3,9 +3,6 @@ title: "In The Dollhouse"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Caught in a corner

--- a/content/music/soliloquy/midnight.md
+++ b/content/music/soliloquy/midnight.md
@@ -3,9 +3,6 @@ title: "Midnight"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I'm feeling wasted

--- a/content/music/soliloquy/narcissism-in-carnage.md
+++ b/content/music/soliloquy/narcissism-in-carnage.md
@@ -3,9 +3,6 @@ title: "Narcissism in Carnage"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I can barely hear the screams

--- a/content/music/soliloquy/off-with-her-head.md
+++ b/content/music/soliloquy/off-with-her-head.md
@@ -3,9 +3,6 @@ title: "Off With Her Head"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You bottled all the blood I bled

--- a/content/music/soliloquy/she-who-is-made-of-salt.md
+++ b/content/music/soliloquy/she-who-is-made-of-salt.md
@@ -3,9 +3,6 @@ title: "She Who is Made of Salt"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I wound so easily

--- a/content/music/soliloquy/to-serve-god-and-my-country.md
+++ b/content/music/soliloquy/to-serve-god-and-my-country.md
@@ -3,9 +3,6 @@ title: "To Serve God and My Country"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Through dishonor and distrust

--- a/content/music/soliloquy/ugly-sick-strange.md
+++ b/content/music/soliloquy/ugly-sick-strange.md
@@ -3,9 +3,6 @@ title: "Ugly Sick & Strange"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I'm pretty convinced

--- a/content/music/the-dollhouse-collection/arise-fair-sun.md
+++ b/content/music/the-dollhouse-collection/arise-fair-sun.md
@@ -3,9 +3,6 @@ title: "Arise Fair Sun [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Romeo was young and he was unfraid

--- a/content/music/the-dollhouse-collection/as-yet-unnamed.md
+++ b/content/music/the-dollhouse-collection/as-yet-unnamed.md
@@ -3,9 +3,6 @@ title: "As Yet Unnamed"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Today

--- a/content/music/the-dollhouse-collection/delilah-mayfair.md
+++ b/content/music/the-dollhouse-collection/delilah-mayfair.md
@@ -3,9 +3,6 @@ title: "Delilah Mayfair"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 No, I've never said it wasn't true

--- a/content/music/the-dollhouse-collection/farewell-licorice-tree.md
+++ b/content/music/the-dollhouse-collection/farewell-licorice-tree.md
@@ -3,9 +3,6 @@ title: "Farewell, Licorice Tree"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Long hair, long beads

--- a/content/music/the-dollhouse-collection/hypocritic-oath-liars-remix.md
+++ b/content/music/the-dollhouse-collection/hypocritic-oath-liars-remix.md
@@ -3,9 +3,6 @@ title: "Hypocritic Oath [Liar's Remix]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You coulda said anything

--- a/content/music/the-dollhouse-collection/hypocritic-oath.md
+++ b/content/music/the-dollhouse-collection/hypocritic-oath.md
@@ -3,9 +3,6 @@ title: "Hypocritic Oath"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You coulda said anything

--- a/content/music/the-dollhouse-collection/midnight.md
+++ b/content/music/the-dollhouse-collection/midnight.md
@@ -3,9 +3,6 @@ title: "Midnight [2007]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I'm feeling wasted

--- a/content/music/the-dollhouse-collection/she-who-is-made-of-salt.md
+++ b/content/music/the-dollhouse-collection/she-who-is-made-of-salt.md
@@ -3,9 +3,6 @@ title: "She Who is Made of Salt [2007]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I wound so easily

--- a/content/music/the-dollhouse-collection/tell-tale-heart.md
+++ b/content/music/the-dollhouse-collection/tell-tale-heart.md
@@ -3,9 +3,6 @@ title: "Electric Mime Symphony - Tell-Tale Heart"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Can you see past angel faces

--- a/content/music/the-dollhouse-collection/the-jesus-song.md
+++ b/content/music/the-dollhouse-collection/the-jesus-song.md
@@ -3,9 +3,6 @@ title: "The Jesus Song"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 "Come on, it'll make you feel good," is what the woman said

--- a/content/music/the-dollhouse-collection/to-my-sisters.md
+++ b/content/music/the-dollhouse-collection/to-my-sisters.md
@@ -3,9 +3,6 @@ title: "To My Sisters..."
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You tell me to realize

--- a/content/music/the-dollhouse-collection/warrior-of-love.md
+++ b/content/music/the-dollhouse-collection/warrior-of-love.md
@@ -3,9 +3,6 @@ title: "Warrior of Love [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 You tell me I don't have to worry

--- a/content/music/the-dollhouse-collection/wretched-hope.md
+++ b/content/music/the-dollhouse-collection/wretched-hope.md
@@ -3,9 +3,6 @@ title: "Wretched Hope"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Don't give up, Hayley Jane, he'll fall in love yet

--- a/content/music/trash-goblin-smash-hits-vol-2/bet-it-on-the-bootstraps.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/bet-it-on-the-bootstraps.md
@@ -3,9 +3,6 @@ title: "Bet It On The Boostraps"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 welcome to the ratrace racetrack honey

--- a/content/music/trash-goblin-smash-hits-vol-2/changeling.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/changeling.md
@@ -3,9 +3,6 @@ title: "changeling"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 take me back under the mound

--- a/content/music/trash-goblin-smash-hits-vol-2/clap-if-you-believe.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/clap-if-you-believe.md
@@ -3,9 +3,6 @@ title: "Clap If You Believe"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 My light is going out

--- a/content/music/trash-goblin-smash-hits-vol-2/closing-theme.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/closing-theme.md
@@ -3,9 +3,6 @@ title: "Closing Theme"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Please like (like! like!)

--- a/content/music/trash-goblin-smash-hits-vol-2/crying-wolf.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/crying-wolf.md
@@ -3,9 +3,6 @@ title: "Crying Wolf"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 woke up crying out in pain

--- a/content/music/trash-goblin-smash-hits-vol-2/heroine-demo.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/heroine-demo.md
@@ -3,9 +3,6 @@ title: "heroine [DEMO]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 watching as the fire consumes us

--- a/content/music/trash-goblin-smash-hits-vol-2/hey-there.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/hey-there.md
@@ -3,9 +3,6 @@ title: "Hey There"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Hey there, pretty boy

--- a/content/music/trash-goblin-smash-hits-vol-2/money-talks-demo.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/money-talks-demo.md
@@ -3,9 +3,6 @@ title: "Money Talks [Demo]"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I won't be quiet

--- a/content/music/trash-goblin-smash-hits-vol-2/of-lily-and-lorelei.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/of-lily-and-lorelei.md
@@ -3,9 +3,6 @@ title: "Of Lily & Lorelei"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Lily was a good girl, she wore white cotton lace

--- a/content/music/trash-goblin-smash-hits-vol-2/trigger-warning.md
+++ b/content/music/trash-goblin-smash-hits-vol-2/trigger-warning.md
@@ -3,9 +3,6 @@ title: "Trigger Warning"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 Times up, butter cup, I just had a premonition

--- a/content/music/unreleased-songs/luv-mice-elf.md
+++ b/content/music/unreleased-songs/luv-mice-elf.md
@@ -3,15 +3,12 @@ title: "Luv Mice Elf"
 ---
 # {{< page-title >}}
 
-## Background
-Lorem Ipsum
-
 ## Lyrics
 {{< lyrics >}}
 I burned so bright I turned to ash
 Or dimmed my light to suit the task
 I did everything that you ask
-At least what I could manage 
+At least what I could manage
 
 I gave my breath until I choked
 I watch the rest go up in smoke
@@ -39,12 +36,12 @@ But when I’m not th e subject of constant adulation
 It might as well be fade to black
 
 I just want to love myself
-I just want to love myself 
+I just want to love myself
 I don’t want anyone else
-I just want to love myself 
+I just want to love myself
 
-Who’d have thought so, who’s have guessed 
-That this would be my final test 
+Who’d have thought so, who’s have guessed
+That this would be my final test
 I should have seen it coming, yet
 Here we fucking stand
 

--- a/templates/song.md
+++ b/templates/song.md
@@ -3,8 +3,11 @@ title: "Title Here"
 ---
 # {{< page-title >}}
 
+<!--
 ## Background
 Lorem Ipsum
+Remove comments if adding content here!
+-->
 
 ## Lyrics
 {{< lyrics >}}


### PR DESCRIPTION
Removes all the sections that say "Background, Lorem Ipsum" and comments that section out on the template (with a note to remove the comments if adding actual content).